### PR TITLE
realism changes

### DIFF
--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -61,11 +61,11 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>9</damageAmountBase> 
+      <damageAmountBase>4</damageAmountBase> 
       <pelletCount>5</pelletCount>
-      <armorPenetrationSharp>3</armorPenetrationSharp>
-      <armorPenetrationBlunt>5.420</armorPenetrationBlunt>
-      <spreadMult>17.8</spreadMult>
+      <armorPenetrationSharp>1</armorPenetrationSharp>
+      <armorPenetrationBlunt>2</armorPenetrationBlunt>
+      <spreadMult>35.6</spreadMult>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
## Additions

Makes .410 bore garbage as it should be from a short barrel of stuff like Taurus judge. 

## Reasoning

.410 works like a shotgun in a pisol package in CE considering how next to no mods add other .410 guns other than the Taurus Judge, while in real life it is just a bad pistol, working best with standard .45 Colt

## Alternatives

Putting up with killing bears with a taurus judge

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
